### PR TITLE
Disable AMS lane eject in spool dialog

### DIFF
--- a/src/components/dialogs/AfcChangeSpoolDialog.vue
+++ b/src/components/dialogs/AfcChangeSpoolDialog.vue
@@ -29,6 +29,7 @@
                                 v-bind="attrs"
                                 class="px-2 minwidth-0 ml-3"
                                 :loading="loadings.includes('ejectSpool')"
+                                :disabled="isAmsUnit"
                                 v-on="onTooltip"
                                 @click="unloadSpool = true">
                                 <v-icon>{{ mdiEject }}</v-icon>
@@ -164,7 +165,7 @@
                     <v-btn color="" text @click="clearSpoolmanSpool">
                         {{ $t('Panels.AfcSpoolPanel.No') }}
                     </v-btn>
-                    <v-btn color="success" text @click="ejectSpool">
+                    <v-btn color="success" text :disabled="isAmsUnit" @click="ejectSpool">
                         {{ $t('Panels.AfcSpoolPanel.Yes') }}
                     </v-btn>
                 </v-card-actions>
@@ -220,6 +221,11 @@ export default class AfcChangeSpoolDialog extends Mixins(AfcMixin, BaseMixin) {
         )
 
         return max_id.toString().length
+    }
+
+    get isAmsUnit() {
+        const unit = this.getAfcUnitObject(this.laneData.unit)
+        return (unit.type ?? '').toUpperCase() === 'AMS'
     }
 
     get headers() {


### PR DESCRIPTION
## Summary
- Disable spool eject button for AMS units in change spool dialog
- Guard eject confirmation for AMS units with new `isAmsUnit` check

## Testing
- `npm run lint`
- `npm test` *(fails: Timed out waiting for http://127.0.0.1:4173/)*

------
https://chatgpt.com/codex/tasks/task_e_68c0852d86cc83268c4ffcb2dfde829e