### PR TITLE
Fix AMS FPS display in AFC panel

### DIFF
--- a/src/components/panels/Afc/AfcPanelExtruder.vue
+++ b/src/components/panels/Afc/AfcPanelExtruder.vue
@@ -138,10 +138,231 @@ export default class AfcPanelExtruder extends Mixins(BaseMixin, AfcMixin) {
     }
 
     get bufferOutput() {
-        const extruder = this.afcCurrentLane?.extruder ?? ''
-        if (extruder !== this.name) return this.$t('Panels.AfcPanel.BufferDisabled')
+        if (!this.isActiveExtruder) return this.$t('Panels.AfcPanel.BufferDisabled')
+
+        if (this.currentFpsOutput) return this.currentFpsOutput
 
         return `${this.afcCurrentLane?.buffer ?? '--'}: ${this.afcCurrentBuffer?.state ?? '--'}`
+    }
+
+    get isActiveExtruder() {
+        const extruder = this.afcCurrentLane?.extruder ?? ''
+
+        return extruder === this.name
+    }
+
+    get isCurrentLaneAms() {
+        if (!this.isActiveExtruder) return false
+
+        const unitNameRaw = this.afcCurrentLane?.unit ?? ''
+        const unitName = unitNameRaw ? unitNameRaw.toString().trim() : ''
+        if (!unitName) return false
+
+        const nameIndicatesAms = unitName.toUpperCase().includes('AMS')
+        if (nameIndicatesAms) return true
+
+        const baseUnitName = this.extractBaseUnitName(unitName)
+        if (!baseUnitName) return false
+
+        const unit = this.getAfcUnitObject(baseUnitName)
+        const unitType = (unit?.type ?? '').toString().toUpperCase()
+
+        return unitType === 'AMS'
+    }
+
+    get printerStateObject() {
+        return (this.$store.state.printer ?? {}) as Record<string, unknown>
+    }
+
+    get oamsManagerStatus(): Record<string, unknown> | null {
+        const manager = this.printerStateObject['oams_manager']
+        if (!manager || typeof manager !== 'object') return null
+
+        return manager as Record<string, unknown>
+    }
+
+    normalizeGroupName(rawGroup: unknown): string | null {
+        if (typeof rawGroup !== 'string') return null
+
+        const normalized = rawGroup.trim().toUpperCase()
+
+        return normalized || null
+    }
+
+    normalizeOamsName(rawName: unknown): string | null {
+        if (typeof rawName !== 'string') return null
+
+        const trimmed = rawName.trim()
+        if (!trimmed) return null
+
+        return trimmed
+    }
+
+    extractBaseUnitName(rawUnit: unknown): string | null {
+        if (typeof rawUnit !== 'string') return null
+
+        const trimmed = rawUnit.trim()
+        if (!trimmed) return null
+
+        const [unit] = trimmed.split(':')
+        if (!unit) return null
+
+        const normalized = unit.trim()
+
+        return normalized || null
+    }
+
+    get currentLaneUnitObject(): Record<string, unknown> | null {
+        const rawUnit = this.afcCurrentLane?.unit ?? ''
+        const baseUnit = this.extractBaseUnitName(rawUnit)
+        if (!baseUnit) return null
+
+        const unit = this.getAfcUnitObject(baseUnit)
+        if (!unit || typeof unit !== 'object') return null
+
+        return unit as Record<string, unknown>
+    }
+
+    get currentLaneOamsName(): string | null {
+        const unit = this.currentLaneUnitObject
+        if (!unit) return null
+
+        const rawName = unit['oams_name'] ?? unit['oams']
+        const normalized = this.normalizeOamsName(rawName)
+
+        return normalized
+    }
+
+    extractGroupFromKey(rawKey: string): string | null {
+        const key = rawKey.trim()
+        if (!key) return null
+
+        const segments = key.split(/\s+/)
+        const suffix = segments[segments.length - 1]
+
+        return this.normalizeGroupName(suffix)
+    }
+
+    resolveOamsStatusKeys(rawName: string): string[] {
+        const keys = new Set<string>()
+        const base = this.normalizeOamsName(rawName)
+        if (!base) return []
+
+        const normalizedBase = base.trim()
+        const normalizedLower = normalizedBase.toLowerCase()
+        const normalizedUpper = normalizedBase.toUpperCase()
+
+        keys.add(normalizedBase)
+        keys.add(normalizedLower)
+        keys.add(normalizedUpper)
+
+        const suffix = normalizedBase.replace(/^oams\s+/i, '').trim()
+        if (suffix) {
+            const suffixLower = suffix.toLowerCase()
+            const suffixUpper = suffix.toUpperCase()
+
+            keys.add(suffix)
+            keys.add(suffixLower)
+            keys.add(suffixUpper)
+            keys.add(`oams ${suffix}`)
+            keys.add(`oams ${suffixLower}`)
+            keys.add(`oams ${suffixUpper}`)
+            keys.add(`OAMS ${suffix}`)
+            keys.add(`OAMS ${suffixLower}`)
+            keys.add(`OAMS ${suffixUpper}`)
+        }
+
+        return Array.from(keys)
+    }
+
+    get currentFpsStatus(): Record<string, unknown> | null {
+        if (!this.isCurrentLaneAms) return null
+
+        const laneMapRaw = this.afcCurrentLane?.map
+        const laneMap = this.normalizeGroupName(laneMapRaw)
+        const laneOamsName = this.currentLaneOamsName
+        const normalizedLaneOams = laneOamsName ? laneOamsName.toUpperCase() : null
+        const oamsManager = this.oamsManagerStatus
+        if (!oamsManager) return null
+
+        let fallbackByOams: Record<string, unknown> | null = null
+        let fallbackByKeyGroup: Record<string, unknown> | null = null
+
+        for (const [key, value] of Object.entries(oamsManager)) {
+            if (key === 'oams') continue
+            if (!value || typeof value !== 'object') continue
+
+            const status = value as Record<string, unknown>
+
+            const currentGroup = this.normalizeGroupName(status['current_group'])
+            if (laneMap && currentGroup && currentGroup === laneMap) return status
+
+            if (!fallbackByOams && normalizedLaneOams) {
+                const statusOams = this.normalizeOamsName(status['current_oams'])
+                const normalizedStatusOams = statusOams ? statusOams.toUpperCase() : null
+
+                if (normalizedStatusOams && normalizedStatusOams === normalizedLaneOams) {
+                    fallbackByOams = status
+                    continue
+                }
+            }
+
+            if (!fallbackByKeyGroup && laneMap) {
+                const keyGroup = this.extractGroupFromKey(key)
+                if (keyGroup && keyGroup === laneMap) {
+                    fallbackByKeyGroup = status
+                }
+            }
+        }
+
+        return fallbackByOams ?? fallbackByKeyGroup
+    }
+
+    get currentOamsName(): string | null {
+        const status = this.currentFpsStatus
+        if (!status) return null
+
+        const name = status['current_oams']
+        if (typeof name !== 'string') return null
+
+        const normalized = this.normalizeOamsName(name)
+
+        return normalized
+    }
+
+    get currentOamsStatus(): Record<string, unknown> | null {
+        const oamsName = this.currentOamsName
+        if (!oamsName) return null
+
+        const keys = this.resolveOamsStatusKeys(oamsName)
+
+        for (const key of keys) {
+            const candidate = this.printerStateObject[key]
+            if (!candidate || typeof candidate !== 'object') continue
+
+            return candidate as Record<string, unknown>
+        }
+
+        return null
+    }
+
+    get currentFpsValue(): number | null {
+        const oamsStatus = this.currentOamsStatus
+        if (!oamsStatus) return null
+
+        const rawValue = oamsStatus['fps_value']
+        const value = typeof rawValue === 'number' ? rawValue : Number(rawValue)
+
+        if (!Number.isFinite(value)) return null
+
+        return value
+    }
+
+    get currentFpsOutput() {
+        const value = this.currentFpsValue
+        if (typeof value !== 'number') return null
+
+        return `fps_value: ${value.toFixed(2)}`
     }
 
     get state() {


### PR DESCRIPTION
## Summary
- ensure AMS lanes are detected even when the AFC unit status lacks an explicit type
- normalize OAMS identifiers and fallback keys to resolve the active unit's status reliably
- surface the active AMS unit fps_value rounded to two decimals in place of the inactive buffer placeholder
- derive the AMS unit's OAMS identifier so remapped tools continue to surface the live fps_value

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb7ce8098c8326bc83dbe54ef407c7