### PR TITLE
feat(afc): sync loaded lane to spoolman extra field

### DIFF
--- a/src/components/dialogs/AfcChangeSpoolDialog.vue
+++ b/src/components/dialogs/AfcChangeSpoolDialog.vue
@@ -367,6 +367,7 @@ export default class AfcChangeSpoolDialog extends Mixins(AfcMixin, BaseMixin) {
 
     clearSpoolmanSpool() {
         if (this.laneData != null) {
+            const currentSpoolId = Number(this.laneData.spool_id || '0')
             const ejectSpoolman = `SET_SPOOL_ID LANE=${this.laneData.name} SPOOL_ID=`
 
             this.$nextTick(async () => {
@@ -386,6 +387,7 @@ export default class AfcChangeSpoolDialog extends Mixins(AfcMixin, BaseMixin) {
                 this.manualyClearSpool()
             }
 
+            this.updateLoadedLaneExtra(currentSpoolId, null)
             this.unloadSpool = false
         }
     }
@@ -429,7 +431,21 @@ export default class AfcChangeSpoolDialog extends Mixins(AfcMixin, BaseMixin) {
                 console.error('Failed to send G-code:', error)
             }
         })
+
+        this.updateLoadedLaneExtra(spool.id, this.laneData?.name ?? null)
         this.close()
+    }
+
+    updateLoadedLaneExtra(spoolId: number, laneName: string | null) {
+        if (!this.spoolManagerUrl) return
+
+        const numericSpoolId = Number(spoolId)
+        if (!numericSpoolId || Number.isNaN(numericSpoolId)) return
+
+        this.$store.dispatch('server/spoolman/updateLoadedLaneExtra', {
+            spoolId: numericSpoolId,
+            laneName,
+        })
     }
 
     initializeFields() {

--- a/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
+++ b/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
@@ -75,6 +75,7 @@
 import Component from 'vue-class-component'
 import { Mixins, Prop, Watch } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
+import AfcMixin from '@/components/mixins/afc'
 import Panel from '@/components/ui/Panel.vue'
 import { mdiCloseThick, mdiAdjust, mdiDatabase, mdiMagnify, mdiRefresh, mdiEject } from '@mdi/js'
 import { ServerSpoolmanStateSpool } from '@/store/server/spoolman/types'
@@ -82,7 +83,7 @@ import SpoolmanChangeSpoolDialogRow from '@/components/dialogs/SpoolmanChangeSpo
 @Component({
     components: { SpoolmanChangeSpoolDialogRow, Panel },
 })
-export default class SpoolmanChangeSpoolDialog extends Mixins(BaseMixin) {
+export default class SpoolmanChangeSpoolDialog extends Mixins(AfcMixin, BaseMixin) {
     mdiAdjust = mdiAdjust
     mdiCloseThick = mdiCloseThick
     mdiDatabase = mdiDatabase
@@ -150,6 +151,31 @@ export default class SpoolmanChangeSpoolDialog extends Mixins(BaseMixin) {
         return 'save_variables' in settings
     }
 
+    get afcLaneObjectData() {
+        if (!this.afcLane) return null
+
+        return this.getAfcLaneObject(this.afcLane)
+    }
+
+    get laneNameForExtra(): string | null {
+        if (!this.afcLane) return null
+
+        const lane = this.afcLaneObjectData as { name?: string } | null
+        const laneName = lane?.name
+
+        if (laneName && laneName.length > 0) return laneName
+
+        return this.afcLane
+    }
+
+    get currentLaneSpoolId(): number {
+        const lane = this.afcLaneObjectData as { spool_id?: string | number } | null
+        if (!lane || lane.spool_id === undefined || lane.spool_id === null) return 0
+
+        const spoolId = Number(lane.spool_id)
+        return Number.isNaN(spoolId) ? 0 : spoolId
+    }
+
     openSpoolManager() {
         window.open(this.spoolManagerUrl, '_blank')
     }
@@ -199,6 +225,7 @@ export default class SpoolmanChangeSpoolDialog extends Mixins(BaseMixin) {
         // if afcLane is set, execute SET_SPOOL_ID and close, because it's not an active printing spool change
         if (this.afcLane) {
             this.sendGcode(`SET_SPOOL_ID LANE=${this.afcLane} SPOOL_ID=${spool.id}`)
+            this.updateLoadedLaneExtra(spool.id, this.laneNameForExtra)
             this.close()
             return
         }
@@ -229,6 +256,18 @@ export default class SpoolmanChangeSpoolDialog extends Mixins(BaseMixin) {
         this.sendGcode(`SAVE_VARIABLE VARIABLE=${this.tool?.toLowerCase()}__spool_id VALUE=${spool.id}`)
     }
 
+    updateLoadedLaneExtra(spoolId: number, laneName: string | null) {
+        if (!this.spoolManagerUrl) return
+
+        const numericSpoolId = Number(spoolId)
+        if (!numericSpoolId || Number.isNaN(numericSpoolId)) return
+
+        this.$store.dispatch('server/spoolman/updateLoadedLaneExtra', {
+            spoolId: numericSpoolId,
+            laneName,
+        })
+    }
+
     sendGcode(gcode: string) {
         this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
         this.$socket.emit('printer.gcode.script', { script: gcode })
@@ -236,6 +275,7 @@ export default class SpoolmanChangeSpoolDialog extends Mixins(BaseMixin) {
 
     ejectSpool() {
         this.sendGcode(`SET_SPOOL_ID LANE=${this.afcLane} SPOOL_ID=`)
+        this.updateLoadedLaneExtra(this.currentLaneSpoolId, null)
         this.close()
     }
 

--- a/src/store/server/spoolman/actions.ts
+++ b/src/store/server/spoolman/actions.ts
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import { ActionTree } from 'vuex'
 import { RootState } from '@/store/types'
 import { ServerSpoolmanState } from '@/store/server/spoolman/types'
+import { SPOOLMAN_LOADED_LANE_EXTRA_FIELD } from '@/store/server/spoolman/constants'
 
 function convertV2response(payload: { error?: { message: string } | null; response: any }) {
     if ((payload.error?.message ?? null) !== null) {
@@ -159,5 +160,44 @@ export const actions: ActionTree<ServerSpoolmanState, RootState> = {
             },
             { action: 'server/spoolman/getActiveSpool' }
         )
+    },
+
+    updateLoadedLaneExtra({ dispatch }, payload: { spoolId: number; laneName: string | null }) {
+        const spoolId = Number(payload.spoolId)
+        if (!spoolId || Number.isNaN(spoolId)) return
+
+        const laneValue = payload.laneName === null ? '' : String(payload.laneName)
+        const encodedValue = JSON.stringify(laneValue)
+
+        Vue.$socket.emit(
+            'server.spoolman.proxy',
+            {
+                request_method: 'PATCH',
+                path: `/v1/spool/${spoolId}`,
+                use_v2_response: true,
+                body: {
+                    extra: {
+                        [SPOOLMAN_LOADED_LANE_EXTRA_FIELD]: encodedValue,
+                    },
+                },
+            },
+            {
+                action: 'server/spoolman/handleUpdateLoadedLaneExtra',
+                requestParams: { spoolId },
+            }
+        )
+
+        dispatch('socket/addLoading', 'updateLoadedLaneExtra', { root: true })
+    },
+
+    handleUpdateLoadedLaneExtra({ dispatch }, payload) {
+        dispatch('socket/removeLoading', 'updateLoadedLaneExtra', { root: true })
+
+        if ('requestParams' in payload) delete payload.requestParams
+
+        payload = convertV2response(payload)
+        if (payload === null) return
+
+        dispatch('refreshSpools')
     },
 }

--- a/src/store/server/spoolman/constants.ts
+++ b/src/store/server/spoolman/constants.ts
@@ -1,0 +1,1 @@
+export const SPOOLMAN_LOADED_LANE_EXTRA_FIELD = 'loaded_lane'

--- a/src/store/server/spoolman/types.ts
+++ b/src/store/server/spoolman/types.ts
@@ -49,4 +49,5 @@ export interface ServerSpoolmanStateSpool {
     used_weight: number
     location?: string
     comment?: string
+    extra?: Record<string, string>
 }


### PR DESCRIPTION
## Summary
- update the AFC spool change dialog to push the loaded lane to the Spoolman extra field when spools are added or removed
- teach the generic Spoolman change dialog to update the loaded lane extra field for AFC lanes
- add a store action and constant for PATCHing the `loaded_lane` extra field on Spoolman spools

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d15cb8ba24832692168d5f167da38a