### PR TITLE
Add OAMS pause event handling

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,6 +18,7 @@
             <the-bed-screws-dialog />
             <the-screws-tilt-adjust-dialog />
             <the-macro-prompt />
+            <the-oams-pause-dialog />
         </template>
         <the-select-printer-dialog v-else-if="instancesDB !== 'moonraker'" />
         <the-connecting-dialog v-else />
@@ -45,6 +46,7 @@ import TheScrewsTiltAdjustDialog from '@/components/dialogs/TheScrewsTiltAdjustD
 import { setAndLoadLocale } from './plugins/i18n'
 import TheMacroPrompt from '@/components/dialogs/TheMacroPrompt.vue'
 import { AppRoute } from '@/routes'
+import TheOamsPauseDialog from '@/components/dialogs/TheOamsPauseDialog.vue'
 
 Component.registerHooks(['metaInfo'])
 
@@ -63,6 +65,7 @@ Component.registerHooks(['metaInfo'])
         TheManualProbeDialog,
         TheBedScrewsDialog,
         TheScrewsTiltAdjustDialog,
+        TheOamsPauseDialog,
     },
 })
 export default class App extends Mixins(BaseMixin, ThemeMixin) {

--- a/src/components/dialogs/TheOamsPauseDialog.vue
+++ b/src/components/dialogs/TheOamsPauseDialog.vue
@@ -1,0 +1,172 @@
+<template>
+    <v-dialog :value="dialogVisible" width="480" persistent :fullscreen="isMobile">
+        <panel
+            v-if="activePause"
+            :title="dialogTitle"
+            :icon="mdiAlert"
+            card-class="oams-pause-dialog"
+            :margin-bottom="false">
+            <v-container>
+                <v-row>
+                    <v-col cols="12" class="text-subtitle-1 font-weight-medium">
+                        {{ activePause.params.message }}
+                    </v-col>
+                </v-row>
+                <v-row>
+                    <v-col cols="12" md="6">
+                        <div class="oams-pause-dialog__label">{{ laneLabel }}</div>
+                        <div class="oams-pause-dialog__value">{{ activePause.params.lane || '-' }}</div>
+                    </v-col>
+                    <v-col cols="12" md="6">
+                        <div class="oams-pause-dialog__label">{{ reasonLabel }}</div>
+                        <div class="oams-pause-dialog__value">{{ readableReason }}</div>
+                    </v-col>
+                </v-row>
+                <v-row v-if="activePause.params.fps || activePause.params.details">
+                    <v-col v-if="activePause.params.fps" cols="12" md="6">
+                        <div class="oams-pause-dialog__label">FPS</div>
+                        <div class="oams-pause-dialog__value">{{ activePause.params.fps }}</div>
+                    </v-col>
+                    <v-col v-if="activePause.params.details" cols="12" md="6">
+                        <div class="oams-pause-dialog__label">{{ detailsLabel }}</div>
+                        <div class="oams-pause-dialog__details">
+                            <div v-for="(value, key) in activePause.params.details" :key="key">
+                                <strong>{{ key }}:</strong>
+                                <span>{{ formatDetail(value) }}</span>
+                            </div>
+                        </div>
+                    </v-col>
+                </v-row>
+            </v-container>
+            <v-card-actions>
+                <v-spacer />
+                <v-btn text color="error" @click="acknowledgePause(false)">
+                    {{ cancelLabel }}
+                </v-btn>
+                <v-btn color="primary" text @click="acknowledgePause(true)">
+                    {{ continueLabel }}
+                </v-btn>
+            </v-card-actions>
+        </panel>
+    </v-dialog>
+</template>
+
+<script lang="ts">
+import { Component, Mixins, Watch } from 'vue-property-decorator'
+import BaseMixin from '@/components/mixins/base'
+import Panel from '@/components/ui/Panel.vue'
+import { PauseEvent } from '@/store/oams'
+import { mdiAlertCircleOutline } from '@mdi/js'
+
+@Component({
+    components: { Panel },
+})
+export default class TheOamsPauseDialog extends Mixins(BaseMixin) {
+    mdiAlert = mdiAlertCircleOutline
+
+    dialogVisible = false
+
+    get dialogTitle(): string {
+        return this.translateOrDefault('App.Dialogs.PauseEvent', 'Pause Event')
+    }
+
+    get cancelLabel(): string {
+        return this.translateOrDefault('JobQueue.Cancel', 'Cancel Print')
+    }
+
+    get continueLabel(): string {
+        return this.translateOrDefault('General.Continue', 'Continue')
+    }
+
+    get laneLabel(): string {
+        return this.translateOrDefault('General.Lane', 'Lane')
+    }
+
+    get reasonLabel(): string {
+        return this.translateOrDefault('General.Reason', 'Reason')
+    }
+
+    get detailsLabel(): string {
+        return this.translateOrDefault('General.Details', 'Details')
+    }
+
+    get activePause(): PauseEvent | null {
+        return this.$store.getters['oams/active'] ?? null
+    }
+
+    get readableReason(): string {
+        const reason = this.activePause?.params.reason
+        if (!reason) return '-'
+        return reason.replace(/_/g, ' ')
+    }
+
+    @Watch('activePause', { immediate: true })
+    onActivePauseChanged(value: PauseEvent | null): void {
+        this.dialogVisible = !!value
+    }
+
+    formatDetail(value: unknown): string {
+        if (value === null || value === undefined) return '-'
+        if (typeof value === 'object') {
+            try {
+                return JSON.stringify(value)
+            } catch (e) {
+                return String(value)
+            }
+        }
+        return String(value)
+    }
+
+    private translateOrDefault(key: string, fallback: string): string {
+        const translated = this.$t(key)?.toString?.() ?? ''
+        if (!translated || translated === key) {
+            return fallback
+        }
+
+        return translated
+    }
+
+    acknowledgePause(resume: boolean) {
+        const pause = this.activePause
+        if (!pause) return
+
+        const body: Record<string, unknown> = {
+            event_id: pause.params.event_id,
+            acknowledged: true,
+        }
+
+        let method = 'oams.pause_ack'
+        if (resume) {
+            method = 'oams.stuck_spool_resume'
+            body.resume_follow = true
+        }
+
+        this.$socket.emit('printer.remote_method', {
+            method,
+            params: body,
+        })
+
+        this.$store.commit('oams/clear', pause.params.event_id)
+        this.dialogVisible = false
+    }
+}
+</script>
+
+<style scoped>
+.oams-pause-dialog__label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    opacity: 0.7;
+}
+
+.oams-pause-dialog__value {
+    font-size: 1rem;
+    word-break: break-word;
+}
+
+.oams-pause-dialog__details {
+    font-size: 0.9rem;
+    display: grid;
+    gap: 0.25rem;
+}
+</style>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -14,6 +14,7 @@ import { gui } from '@/store/gui'
 import { farm } from '@/store/farm'
 import { editor } from '@/store/editor'
 import { gcodeviewer } from '@/store/gcodeviewer'
+import { oams } from '@/store/oams'
 
 Vue.use(Vuex)
 
@@ -40,6 +41,7 @@ export default new Vuex.Store({
         farm,
         editor,
         gcodeviewer,
+        oams,
     },
     getters: getters,
     mutations: mutations,

--- a/src/store/oams/index.ts
+++ b/src/store/oams/index.ts
@@ -1,0 +1,77 @@
+import { Module } from 'vuex'
+import { RootState } from '@/store/types'
+
+export type PauseEvent = {
+    method: string
+    params: {
+        event_id: string
+        message: string
+        reason?: string
+        requires_ack?: boolean
+        [key: string]: any
+    }
+}
+
+export type OamsState = {
+    pending: Record<string, PauseEvent>
+    activeId: string | null
+}
+
+const getNextActiveId = (pending: Record<string, PauseEvent>): string | null => {
+    return Object.keys(pending)[0] ?? null
+}
+
+export const oams: Module<OamsState, RootState> = {
+    namespaced: true,
+    state: (): OamsState => ({
+        pending: {},
+        activeId: null,
+    }),
+    getters: {
+        active(state): PauseEvent | null {
+            if (!state.activeId) return null
+            return state.pending[state.activeId] ?? null
+        },
+        pendingList(state): PauseEvent[] {
+            return Object.values(state.pending)
+        },
+    },
+    mutations: {
+        enqueue(state, payload: PauseEvent) {
+            const eventId = payload?.params?.event_id
+            if (!eventId) return
+
+            state.pending = {
+                ...state.pending,
+                [eventId]: payload,
+            }
+
+            if (!state.activeId) {
+                state.activeId = eventId
+            }
+        },
+        clear(state, eventId: string) {
+            if (!eventId) return
+            if (state.pending[eventId]) {
+                const nextPending = { ...state.pending }
+                delete nextPending[eventId]
+                state.pending = nextPending
+            }
+
+            if (state.activeId === eventId) {
+                state.activeId = getNextActiveId(state.pending)
+            }
+        },
+        setActive(state, eventId: string | null) {
+            if (eventId && !state.pending[eventId]) return
+            state.activeId = eventId
+        },
+    },
+    actions: {
+        handleRemoteEvent({ commit }, remote: PauseEvent) {
+            if (remote.method === 'oams.pause_event') {
+                commit('enqueue', remote)
+            }
+        },
+    },
+}

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -11,7 +11,6 @@ import {
     PrinterStateMcu,
     PrinterStateMacro,
     PrinterGetterObject,
-    PrinterStateLight,
 } from '@/store/printer/types'
 import { caseInsensitiveSort, formatFrequency, getMacroParams } from '@/plugins/helpers'
 import { RootState } from '@/store/types'

--- a/src/store/socket/actions.ts
+++ b/src/store/socket/actions.ts
@@ -115,6 +115,14 @@ export const actions: ActionTree<SocketState, RootState> = {
                 dispatch('server/jobQueue/getEvent', payload.params[0], { root: true })
                 break
 
+            case 'notify_remote_method': {
+                const remote = payload.params?.[0]
+                if (remote?.method?.startsWith('oams.')) {
+                    dispatch('oams/handleRemoteEvent', remote, { root: true })
+                }
+                break
+            }
+
             case 'notify_announcement_update':
                 dispatch('server/announcements/getList', payload.params[0], { root: true })
                 break

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -3,6 +3,7 @@ import { ServerState } from '@/store/server/types'
 import { PrinterState } from '@/store/printer/types'
 import { GuiState } from '@/store/gui/types'
 import { EditorState } from '@/store/editor/types'
+import { OamsState } from '@/store/oams'
 
 export interface RootState {
     packageVersion: string
@@ -16,6 +17,7 @@ export interface RootState {
     printer?: PrinterState
     server?: ServerState
     editor?: EditorState
+    oams?: OamsState
 }
 
 export interface RootStateDependency {


### PR DESCRIPTION
## Summary
- route Moonraker notify_remote_method events into a dedicated OAMS store module
- track pause events and expose a dialog component with continue and cancel workflows
- register the module with Vuex, wire the dialog into App.vue, and clean up an unused printer getter import

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d83e76a23083269d4b5888b7535664