### PR TITLE
Fix OpenAMS pause event handling

### DIFF
--- a/src/store/oams/index.ts
+++ b/src/store/oams/index.ts
@@ -1,15 +1,22 @@
 import { Module } from 'vuex'
 import { RootState } from '@/store/types'
 
+type PauseEventParams = {
+    event_id: string
+    message: string
+    reason?: string
+    requires_ack?: boolean
+    [key: string]: any
+}
+
 export type PauseEvent = {
     method: string
-    params: {
-        event_id: string
-        message: string
-        reason?: string
-        requires_ack?: boolean
-        [key: string]: any
-    }
+    params: PauseEventParams
+}
+
+type PauseEventPayload = {
+    method?: string
+    params?: PauseEventParams | PauseEventParams[] | null
 }
 
 export type OamsState = {
@@ -19,6 +26,21 @@ export type OamsState = {
 
 const getNextActiveId = (pending: Record<string, PauseEvent>): string | null => {
     return Object.keys(pending)[0] ?? null
+}
+
+const normalizePauseEvent = (payload: PauseEventPayload): PauseEvent | null => {
+    if (!payload?.method) return null
+
+    const params = Array.isArray(payload.params) ? payload.params[0] : payload.params
+    if (!params || typeof params !== 'object') return null
+
+    const eventId = (params as PauseEventParams).event_id
+    if (!eventId) return null
+
+    return {
+        method: payload.method,
+        params: params as PauseEventParams,
+    }
 }
 
 export const oams: Module<OamsState, RootState> = {
@@ -68,9 +90,10 @@ export const oams: Module<OamsState, RootState> = {
         },
     },
     actions: {
-        handleRemoteEvent({ commit }, remote: PauseEvent) {
-            if (remote.method === 'oams.pause_event') {
-                commit('enqueue', remote)
+        handleRemoteEvent({ commit }, remote: PauseEventPayload) {
+            const pauseEvent = normalizePauseEvent(remote)
+            if (pauseEvent?.method === 'oams.pause_event') {
+                commit('enqueue', pauseEvent)
             }
         },
     },

--- a/src/store/socket/actions.ts
+++ b/src/store/socket/actions.ts
@@ -116,9 +116,9 @@ export const actions: ActionTree<SocketState, RootState> = {
                 break
 
             case 'notify_remote_method': {
-                const remote = payload.params?.[0]
-                if (remote?.method?.startsWith('oams.')) {
-                    dispatch('oams/handleRemoteEvent', remote, { root: true })
+                const remoteParams = Array.isArray(payload.params) ? payload.params[0] : payload.params
+                if (remoteParams?.method?.startsWith?.('oams.')) {
+                    dispatch('oams/handleRemoteEvent', remoteParams, { root: true })
                 }
                 break
             }


### PR DESCRIPTION
## Summary
- normalize OpenAMS pause event payloads so queued dialogs always include an event id
- support both array and object payloads for `notify_remote_method` notifications before dispatching OpenAMS handlers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d85277f2e08326b462c26e36658606