### PR TITLE
Handle OpenAMS remote method alias for pause events

### DIFF
--- a/src/store/oams/index.ts
+++ b/src/store/oams/index.ts
@@ -1,15 +1,23 @@
 import { Module } from 'vuex'
 import { RootState } from '@/store/types'
 
+type PauseEventParams = {
+    event_id: string
+    message: string
+    reason?: string
+    requires_ack?: boolean
+    [key: string]: any
+}
+
 export type PauseEvent = {
     method: string
-    params: {
-        event_id: string
-        message: string
-        reason?: string
-        requires_ack?: boolean
-        [key: string]: any
-    }
+    params: PauseEventParams
+}
+
+type PauseEventPayload = {
+    method?: string
+    name?: string
+    params?: PauseEventParams | PauseEventParams[] | null
 }
 
 export type OamsState = {
@@ -19,6 +27,52 @@ export type OamsState = {
 
 const getNextActiveId = (pending: Record<string, PauseEvent>): string | null => {
     return Object.keys(pending)[0] ?? null
+}
+
+const isPauseEventMethod = (method: string | null | undefined): method is string => {
+    if (typeof method !== 'string') return false
+
+    return method === 'oams.pause_event' || method === 'open_ams.pause_event'
+}
+
+const getPauseEventMethod = (payload: PauseEventPayload): string | null => {
+    if (typeof payload?.method === 'string') return payload.method
+    if (typeof payload?.name === 'string') return payload.name
+    return null
+}
+
+const getPauseEventParams = (
+    params?: PauseEventParams | PauseEventParams[] | null
+): Record<string, unknown> | null => {
+    if (Array.isArray(params)) {
+        const firstParam = params.find((param) => param && typeof param === 'object')
+        return (firstParam as Record<string, unknown>) ?? null
+    }
+
+    if (params && typeof params === 'object') return params as Record<string, unknown>
+
+    return null
+}
+
+const normalizePauseEvent = (payload: PauseEventPayload): PauseEvent | null => {
+    const method = getPauseEventMethod(payload)
+    if (!isPauseEventMethod(method)) return null
+
+    const params = getPauseEventParams(payload.params)
+    if (!params) return null
+
+    const rawEventId = params.event_id ?? params.eventId ?? params.eventID
+    if (rawEventId === undefined || rawEventId === null) return null
+
+    const eventId = String(rawEventId)
+
+    return {
+        method,
+        params: {
+            ...(params as PauseEventParams),
+            event_id: eventId,
+        },
+    }
 }
 
 export const oams: Module<OamsState, RootState> = {
@@ -68,9 +122,10 @@ export const oams: Module<OamsState, RootState> = {
         },
     },
     actions: {
-        handleRemoteEvent({ commit }, remote: PauseEvent) {
-            if (remote.method === 'oams.pause_event') {
-                commit('enqueue', remote)
+        handleRemoteEvent({ commit }, remote: PauseEventPayload) {
+            const pauseEvent = normalizePauseEvent(remote)
+            if (pauseEvent && isPauseEventMethod(pauseEvent.method)) {
+                commit('enqueue', pauseEvent)
             }
         },
     },

--- a/src/store/socket/actions.ts
+++ b/src/store/socket/actions.ts
@@ -116,9 +116,27 @@ export const actions: ActionTree<SocketState, RootState> = {
                 break
 
             case 'notify_remote_method': {
-                const remote = payload.params?.[0]
-                if (remote?.method?.startsWith('oams.')) {
-                    dispatch('oams/handleRemoteEvent', remote, { root: true })
+                const remoteParams = Array.isArray(payload.params) ? payload.params[0] : payload.params
+                if (!remoteParams || typeof remoteParams !== 'object') break
+
+                const remoteRecord = remoteParams as Record<string, unknown>
+                const remoteMethod =
+                    typeof remoteRecord.method === 'string'
+                        ? remoteRecord.method
+                        : typeof remoteRecord.name === 'string'
+                          ? remoteRecord.name
+                          : undefined
+
+                if (
+                    typeof remoteMethod === 'string' &&
+                    (remoteMethod.startsWith('oams.') || remoteMethod.startsWith('open_ams.'))
+                ) {
+                    const normalizedRemote =
+                        remoteParams.method === remoteMethod
+                            ? remoteParams
+                            : { ...remoteParams, method: remoteMethod }
+
+                    dispatch('oams/handleRemoteEvent', normalizedRemote, { root: true })
                 }
                 break
             }


### PR DESCRIPTION
## Summary
- normalize OpenAMS pause event payloads so queued dialogs always include an event id
- support both array and object payloads for `notify_remote_method` notifications before dispatching OpenAMS handlers
- accept OpenAMS remote events that use `open_ams` method names and normalize event ids from alternative fields

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d85277f2e08326b462c26e36658606