### PR TITLE
Broaden OpenAMS remote event parsing

### DIFF
--- a/src/store/oams/index.ts
+++ b/src/store/oams/index.ts
@@ -1,15 +1,26 @@
 import { Module } from 'vuex'
 import { RootState } from '@/store/types'
 
+type PauseEventParams = {
+    event_id: string
+    message: string
+    reason?: string
+    requires_ack?: boolean
+    [key: string]: any
+}
+
 export type PauseEvent = {
     method: string
-    params: {
-        event_id: string
-        message: string
-        reason?: string
-        requires_ack?: boolean
-        [key: string]: any
-    }
+    params: PauseEventParams
+}
+
+type PauseEventPayload = {
+    method?: string
+    name?: string
+    remote_method?: string
+    params?: unknown
+    args?: unknown
+    payload?: unknown
 }
 
 export type OamsState = {
@@ -19,6 +30,77 @@ export type OamsState = {
 
 const getNextActiveId = (pending: Record<string, PauseEvent>): string | null => {
     return Object.keys(pending)[0] ?? null
+}
+
+const isPauseEventMethod = (method: string | null | undefined): method is string => {
+    if (typeof method !== 'string') return false
+
+    return method === 'oams.pause_event' || method === 'open_ams.pause_event'
+}
+
+const methodKeys: Array<keyof PauseEventPayload> = ['method', 'name', 'remote_method']
+
+const getPauseEventMethod = (payload: PauseEventPayload): string | null => {
+    for (const key of methodKeys) {
+        const value = payload?.[key]
+        if (typeof value === 'string') return value
+    }
+    return null
+}
+
+const pauseParamKeys = ['event', 'params', 'payload', 'data', 'args'] as const
+
+const findPauseEventParams = (value: unknown, depth = 0): Record<string, unknown> | null => {
+    if (depth > 5 || value === null || value === undefined) return null
+
+    if (Array.isArray(value)) {
+        for (const item of value) {
+            const nested = findPauseEventParams(item, depth + 1)
+            if (nested) return nested
+        }
+        return null
+    }
+
+    if (typeof value === 'object') {
+        const record = value as Record<string, unknown>
+        if (
+            record.event_id !== undefined ||
+            record.eventId !== undefined ||
+            record.eventID !== undefined
+        ) {
+            return record
+        }
+
+        for (const key of pauseParamKeys) {
+            if (key in record) {
+                const nested = findPauseEventParams(record[key], depth + 1)
+                if (nested) return nested
+            }
+        }
+    }
+
+    return null
+}
+
+const normalizePauseEvent = (payload: PauseEventPayload): PauseEvent | null => {
+    const method = getPauseEventMethod(payload)
+    if (!isPauseEventMethod(method)) return null
+
+    const params = findPauseEventParams([payload.params, payload.args, payload.payload, payload])
+    if (!params) return null
+
+    const rawEventId = params.event_id ?? params.eventId ?? params.eventID
+    if (rawEventId === undefined || rawEventId === null) return null
+
+    const eventId = String(rawEventId)
+
+    return {
+        method,
+        params: {
+            ...(params as PauseEventParams),
+            event_id: eventId,
+        },
+    }
 }
 
 export const oams: Module<OamsState, RootState> = {
@@ -68,9 +150,10 @@ export const oams: Module<OamsState, RootState> = {
         },
     },
     actions: {
-        handleRemoteEvent({ commit }, remote: PauseEvent) {
-            if (remote.method === 'oams.pause_event') {
-                commit('enqueue', remote)
+        handleRemoteEvent({ commit }, remote: PauseEventPayload) {
+            const pauseEvent = normalizePauseEvent(remote)
+            if (pauseEvent && isPauseEventMethod(pauseEvent.method)) {
+                commit('enqueue', pauseEvent)
             }
         },
     },

--- a/src/store/socket/actions.ts
+++ b/src/store/socket/actions.ts
@@ -3,6 +3,99 @@ import { ActionTree } from 'vuex'
 import { SocketState } from '@/store/socket/types'
 import { RootState } from '@/store/types'
 
+type RemotePayload = {
+    method?: string
+    name?: string
+    remote_method?: string
+    params?: unknown
+    args?: unknown
+    payload?: unknown
+    [key: string]: unknown
+}
+
+const remoteMethodKeys: Array<'method' | 'name' | 'remote_method'> = ['method', 'name', 'remote_method']
+
+const getRemoteMethod = (payload: RemotePayload | null): string | null => {
+    if (!payload) return null
+
+    for (const key of remoteMethodKeys) {
+        const value = payload[key]
+        if (typeof value === 'string') return value
+    }
+
+    return null
+}
+
+const isRecord = (value: unknown): value is RemotePayload => {
+    return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+const isRemoteCandidate = (value: unknown): value is RemotePayload => {
+    if (!isRecord(value)) return false
+
+    return remoteMethodKeys.some((key) => typeof value[key] === 'string')
+}
+
+const buildRemoteFromTuple = (
+    methodCandidate: unknown,
+    paramsCandidate: unknown
+): RemotePayload | null => {
+    if (typeof methodCandidate === 'string') {
+        const remote: RemotePayload = { method: methodCandidate }
+
+        if (isRecord(paramsCandidate)) {
+            if ('params' in paramsCandidate || 'args' in paramsCandidate) {
+                return {
+                    ...paramsCandidate,
+                    method: methodCandidate,
+                }
+            }
+
+            return {
+                method: methodCandidate,
+                params: paramsCandidate,
+            }
+        }
+
+        return remote
+    }
+
+    if (isRemoteCandidate(methodCandidate)) {
+        return methodCandidate
+    }
+
+    if (isRemoteCandidate(paramsCandidate)) {
+        return paramsCandidate
+    }
+
+    return null
+}
+
+const extractRemotePayload = (params: unknown): RemotePayload | null => {
+    if (Array.isArray(params)) {
+        for (const item of params) {
+            if (isRemoteCandidate(item)) return item
+        }
+
+        if (params.length >= 2) {
+            for (let index = 0; index < params.length - 1; index += 1) {
+                const candidate = buildRemoteFromTuple(params[index], params[index + 1])
+                if (candidate) return candidate
+            }
+        }
+
+        if (params.length === 1) {
+            return buildRemoteFromTuple(params[0], undefined)
+        }
+
+        return null
+    }
+
+    if (isRemoteCandidate(params)) return params
+
+    return null
+}
+
 export const actions: ActionTree<SocketState, RootState> = {
     reset({ commit }) {
         commit('setDisconnected')
@@ -116,9 +209,19 @@ export const actions: ActionTree<SocketState, RootState> = {
                 break
 
             case 'notify_remote_method': {
-                const remote = payload.params?.[0]
-                if (remote?.method?.startsWith('oams.')) {
-                    dispatch('oams/handleRemoteEvent', remote, { root: true })
+                const remotePayload = extractRemotePayload(payload.params)
+                const remoteMethod = getRemoteMethod(remotePayload ?? null)
+
+                if (
+                    typeof remoteMethod === 'string' &&
+                    (remoteMethod.startsWith('oams.') || remoteMethod.startsWith('open_ams.'))
+                ) {
+                    const normalizedRemote =
+                        remotePayload && remotePayload.method === remoteMethod
+                            ? remotePayload
+                            : { ...(remotePayload ?? {}), method: remoteMethod }
+
+                    dispatch('oams/handleRemoteEvent', normalizedRemote, { root: true })
                 }
                 break
             }


### PR DESCRIPTION
## Summary
- normalize OpenAMS pause event payloads so queued dialogs always include an event id
- support array, object, or tuple `notify_remote_method` payloads when dispatching OpenAMS handlers
- accept OpenAMS remote events that use `open_ams` method names and normalize event ids from alternative fields
- recursively search nested remote params and args payloads to recover pause event metadata before enqueuing dialogs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d85277f2e08326b462c26e36658606