### PR TITLE
Show direct hub load for boxturtle units

### DIFF
--- a/src/components/panels/Afc/AfcPanelUnit.vue
+++ b/src/components/panels/Afc/AfcPanelUnit.vue
@@ -7,7 +7,12 @@
                     {{ unitNameOutput }}
                 </h3>
                 <v-spacer />
-                <afc-panel-unit-hub v-for="hub in hubs" :key="hub" :name="hub" />
+                <afc-panel-unit-hub
+                    v-for="hub in hubs"
+                    :key="hub"
+                    :name="hub"
+                    :unit-type="type"
+                    :lanes="lanes" />
             </v-col>
         </v-row>
         <v-row>

--- a/src/components/panels/Afc/AfcPanelUnitHub.vue
+++ b/src/components/panels/Afc/AfcPanelUnitHub.vue
@@ -21,12 +21,16 @@ import AfcMixin from '@/components/mixins/afc'
 @Component
 export default class AfcPanelUnitHub extends Mixins(BaseMixin, AfcMixin) {
     @Prop({ type: String, required: true }) readonly name!: string
+    @Prop({ type: String, default: '' }) readonly unitType!: string
+    @Prop({ type: Array, default: () => [] }) readonly lanes!: string[]
 
     get hub() {
         return this.getAfcHubObject(this.name)
     }
 
     get sensorStatus() {
+        if (this.directLaneLoaded) return true
+
         return this.hub.state ?? false
     }
 
@@ -41,6 +45,67 @@ export default class AfcPanelUnitHub extends Mixins(BaseMixin, AfcMixin) {
             success: this.sensorStatus,
             error: !this.sensorStatus,
         }
+    }
+
+    get directLaneLoaded() {
+        if (this.unitType.toLowerCase() !== 'boxturtle') return false
+
+        return this.lanesForHub.some((laneName) => {
+            const laneSettings = this.getLaneSettings(laneName)
+            const hubSetting = this.normalizeHubName(laneSettings?.hub)
+            if (!['direct', 'direct_load'].includes(hubSetting)) return false
+
+            const lane = this.getLaneObject(laneName)
+
+            return Boolean(lane?.tool_loaded)
+        })
+    }
+
+    get lanesForHub(): string[] {
+        const hubName = this.normalizeHubName(this.name)
+        if (!hubName) return []
+
+        return this.lanes.filter((laneName) => {
+            const lane = this.getLaneObject(laneName)
+            const laneHub = this.normalizeHubName(lane?.hub) || this.normalizeHubName(lane?.hub_name)
+            if (laneHub === hubName) return true
+
+            const laneSettings = this.getLaneSettings(laneName)
+            const settingsHub = this.normalizeHubName(laneSettings?.hub)
+
+            return settingsHub === hubName
+        })
+    }
+
+    getLaneObject(laneName: string) {
+        return (this.getAfcLaneObject(laneName) ?? {}) as Record<string, any>
+    }
+
+    getLaneSettings(laneName: string) {
+        return (this.getAfcLaneSettings(laneName) ?? {}) as Record<string, any>
+    }
+
+    normalizeHubName(value: unknown) {
+        if (!value) return ''
+
+        if (typeof value === 'string') {
+            const normalized = value.trim().toLowerCase()
+            if (normalized.startsWith('hub:')) {
+                return normalized.slice(4).trim()
+            }
+
+            return normalized
+        }
+
+        if (typeof value === 'object') {
+            const record = value as Record<string, unknown>
+            const nameValue = record?.name
+            if (typeof nameValue === 'string') {
+                return this.normalizeHubName(nameValue)
+            }
+        }
+
+        return ''
     }
 }
 </script>


### PR DESCRIPTION
## Summary
- pass unit type and lane context to the hub indicator component
- mark boxturtle direct hubs as loaded when their lane is tool-loaded

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e02c11e0808326a1c8c6c253022c9f