### PR TITLE
Sync spoolman loaded lane metadata on AFC lane updates

### DIFF
--- a/src/components/dialogs/AfcChangeSpoolDialog.vue
+++ b/src/components/dialogs/AfcChangeSpoolDialog.vue
@@ -402,7 +402,7 @@ export default class AfcChangeSpoolDialog extends Mixins(AfcMixin, BaseMixin) {
 
 
             if (currentSpoolId !== null) {
-                this.updateLoadedLaneExtra(currentSpoolId, null)
+                this.updateSpoolmanLoadedLaneExtra(currentSpoolId, null)
             }
 
             this.unloadSpool = false
@@ -443,7 +443,7 @@ export default class AfcChangeSpoolDialog extends Mixins(AfcMixin, BaseMixin) {
 
         const previousSpoolId = this.currentLaneSpoolId
         if (previousSpoolId !== null && previousSpoolId !== Number(spool.id)) {
-            this.updateLoadedLaneExtra(previousSpoolId, null)
+            this.updateSpoolmanLoadedLaneExtra(previousSpoolId, null)
         }
 
         this.$nextTick(async () => {
@@ -454,22 +454,8 @@ export default class AfcChangeSpoolDialog extends Mixins(AfcMixin, BaseMixin) {
             }
         })
 
-        this.updateLoadedLaneExtra(spool.id, this.laneData?.name ?? null)
+        this.updateSpoolmanLoadedLaneExtra(spool.id, this.laneData?.name ?? null)
         this.close()
-    }
-
-    updateLoadedLaneExtra(spoolId: number, laneName: string | null) {
-        if (!this.spoolManagerUrl) return
-
-        const numericSpoolId = Number(spoolId)
-
-        if (Number.isNaN(numericSpoolId) || numericSpoolId <= 0) return
-
-
-        this.$store.dispatch('server/spoolman/updateLoadedLaneExtra', {
-            spoolId: numericSpoolId,
-            laneName,
-        })
     }
 
     initializeFields() {

--- a/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
+++ b/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
@@ -230,11 +230,11 @@ export default class SpoolmanChangeSpoolDialog extends Mixins(AfcMixin, BaseMixi
         if (this.afcLane) {
             const previousSpoolId = this.currentLaneSpoolId
             if (previousSpoolId !== null && previousSpoolId !== spool.id) {
-                this.updateLoadedLaneExtra(previousSpoolId, null)
+                this.updateSpoolmanLoadedLaneExtra(previousSpoolId, null)
             }
 
             this.sendGcode(`SET_SPOOL_ID LANE=${this.afcLane} SPOOL_ID=${spool.id}`)
-            this.updateLoadedLaneExtra(spool.id, this.laneNameForExtra)
+            this.updateSpoolmanLoadedLaneExtra(spool.id, this.laneNameForExtra)
             this.close()
             return
         }
@@ -265,20 +265,6 @@ export default class SpoolmanChangeSpoolDialog extends Mixins(AfcMixin, BaseMixi
         this.sendGcode(`SAVE_VARIABLE VARIABLE=${this.tool?.toLowerCase()}__spool_id VALUE=${spool.id}`)
     }
 
-    updateLoadedLaneExtra(spoolId: number, laneName: string | null) {
-        if (!this.spoolManagerUrl) return
-
-        const numericSpoolId = Number(spoolId)
-
-        if (Number.isNaN(numericSpoolId) || numericSpoolId <= 0) return
-
-
-        this.$store.dispatch('server/spoolman/updateLoadedLaneExtra', {
-            spoolId: numericSpoolId,
-            laneName,
-        })
-    }
-
     sendGcode(gcode: string) {
         this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
         this.$socket.emit('printer.gcode.script', { script: gcode })
@@ -291,7 +277,7 @@ export default class SpoolmanChangeSpoolDialog extends Mixins(AfcMixin, BaseMixi
 
 
         if (currentSpoolId !== null) {
-            this.updateLoadedLaneExtra(currentSpoolId, null)
+            this.updateSpoolmanLoadedLaneExtra(currentSpoolId, null)
         }
 
         this.close()

--- a/src/components/mixins/afc.ts
+++ b/src/components/mixins/afc.ts
@@ -94,6 +94,19 @@ export default class AfcMixin extends Vue {
         return this.$store.state.server.config.config?.spoolman?.server ?? null
     }
 
+    updateSpoolmanLoadedLaneExtra(spoolId: number, laneName: string | null) {
+        if (!this.spoolManagerUrl) return
+
+        const numericSpoolId = Number(spoolId)
+
+        if (Number.isNaN(numericSpoolId) || numericSpoolId <= 0) return
+
+        this.$store.dispatch('server/spoolman/updateLoadedLaneExtra', {
+            spoolId: numericSpoolId,
+            laneName,
+        })
+    }
+
     get afcShowFilamentName(): boolean {
         return this.$store.state.gui.view.afc?.showFilamentName ?? false
     }

--- a/src/components/panels/Afc/AfcPanelUnitLaneBody.vue
+++ b/src/components/panels/Afc/AfcPanelUnitLaneBody.vue
@@ -52,7 +52,7 @@
     </div>
 </template>
 <script lang="ts">
-import { Component, Mixins, Prop } from 'vue-property-decorator'
+import { Component, Mixins, Prop, Watch } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import AfcMixin from '@/components/mixins/afc'
 import { ServerSpoolmanStateSpool } from '@/store/server/spoolman/types'
@@ -74,6 +74,35 @@ export default class AfcPanelUnitLaneBody extends Mixins(BaseMixin, AfcMixin) {
     showInfintiyDialog = false
     showSpoolmanDialog = false
     showFilamentDialog = false
+
+    private normalizeSpoolId(spoolId: string | number | null | undefined): number | null {
+        const numericSpoolId = Number(spoolId)
+
+        if (Number.isNaN(numericSpoolId) || numericSpoolId <= 0) return null
+
+        return numericSpoolId
+    }
+
+    private syncLoadedLaneExtra(oldSpoolId: number | null, newSpoolId: number | null) {
+        if (!this.spoolManagerUrl) return
+        if (oldSpoolId === newSpoolId) return
+
+        if (oldSpoolId !== null) {
+            this.updateSpoolmanLoadedLaneExtra(oldSpoolId, null)
+        }
+
+        if (newSpoolId !== null) {
+            this.updateSpoolmanLoadedLaneExtra(newSpoolId, this.name)
+        }
+    }
+
+    @Watch('lane.spool_id')
+    onLaneSpoolIdChanged(newValue: string | number | null | undefined, oldValue: string | number | null | undefined) {
+        const oldSpoolId = this.normalizeSpoolId(oldValue)
+        const newSpoolId = this.normalizeSpoolId(newValue)
+
+        this.syncLoadedLaneExtra(oldSpoolId, newSpoolId)
+    }
 
     get lane() {
         return this.getAfcLaneObject(this.name)


### PR DESCRIPTION
## Summary
- add a shared helper in the AFC mixin to update the Spoolman loaded_lane metadata
- trigger metadata updates from the AFC panel when lane spool assignments change
- reuse the helper across AFC and Spoolman change spool dialogs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5911fa16483268caab8729e875b45