### PR TITLE
Merge upstream PRs #2271 and #2272

### DIFF
--- a/src/components/inputs/MacroButton.vue
+++ b/src/components/inputs/MacroButton.vue
@@ -12,6 +12,7 @@
                     v-bind="attrs"
                     v-on="on"
                     @click="doSendMacro(macro.name)">
+                    <v-icon v-if="icon" small left>{{ icon }}</v-icon>
                     {{ alias ? alias : macro.name.replace(/_/g, ' ') }}
                 </v-btn>
             </template>
@@ -150,6 +151,9 @@ export default class MacroButton extends Mixins(BaseMixin) {
 
     @Prop({ default: false })
     declare readonly disabled: boolean
+
+    @Prop({ default: null })
+    declare readonly icon: string
 
     get klipperMacro() {
         return this.$store.getters['printer/getMacro'](this.macro.name)

--- a/src/components/mixins/afc.ts
+++ b/src/components/mixins/afc.ts
@@ -128,6 +128,10 @@ export default class AfcMixin extends Vue {
         return this.$store.state.gui.view.afc?.hiddenUnits ?? []
     }
 
+    get afcShowToolChangeCount(): boolean {
+        return this.$store.state.gui.view.afc?.showToolChangeCount ?? true
+    }
+
     getPrinterObject(key: string) {
         const printer = this.$store.state.printer ?? {}
         return printer[key] ?? null
@@ -188,5 +192,9 @@ export default class AfcMixin extends Vue {
     getAfcHubObject(hub: string) {
         const key = `AFC_hub ${hub}`
         return this.getPrinterObject(key) ?? {}
+    }
+
+    get currentFilamentChange() {
+        return this.$store.state.printer.AFC?.current_toolchange ?? null
     }
 }

--- a/src/components/panels/Afc/AfcPanelButtons.vue
+++ b/src/components/panels/Afc/AfcPanelButtons.vue
@@ -6,14 +6,14 @@
             </v-btn>
         </template>
         <v-list dense>
-            <v-list-item v-for="command in commands" :key="command.command">
-                <v-btn class="w-100" small @click="doSend(command.command)">
-                    <v-icon v-if="command.icon" small left>{{ command.icon }}</v-icon>
-                    {{ command.text }}
-                </v-btn>
-            </v-list-item>
             <v-list-item v-for="macro in macros" :key="macro.macroName">
-                <macro-button :macro="macro.macro" :alias="macro.text" color="" class="w-100" />
+                <macro-button
+                    :macro="macro.macro"
+                    :alias="macro.text"
+                    :icon="macro.icon"
+                    :disabled="macro.disabled"
+                    color=""
+                    class="w-100" />
             </v-list-item>
             <v-list-item>
                 <v-btn class="w-100" small @click="showAfcSettings = true">
@@ -53,48 +53,39 @@ export default class AfcPanelButtons extends Mixins(BaseMixin, AfcMixin) {
 
     showAfcSettings = false
 
-    get commands() {
-        const commands = this.$store.state.printer.gcode?.commands ?? {}
-        const commandsList = Object.keys(commands)
-
-        const buttons = [
-            {
-                icon: mdiWrench,
-                text: this.$t('Panels.AfcPanel.Calibrate'),
-                command: 'AFC_CALIBRATION',
-                disabled: false,
-            },
-        ]
-
-        const ledState = this.afc.led_state ?? false
-        if (ledState) {
-            buttons.push({
-                icon: mdiLightbulbOnOutline,
-                text: this.$t('Panels.AfcPanel.LedOff'),
-                command: 'TURN_OFF_AFC_LED',
-                disabled: false,
-            })
-        } else {
-            buttons.push({
-                icon: mdiLightbulbOutline,
-                text: this.$t('Panels.AfcPanel.LedOn'),
-                command: 'TURN_ON_AFC_LED',
-                disabled: false,
-            })
-        }
-
-        return buttons.filter((button) => {
-            return commandsList.includes(button.command.toUpperCase())
-        })
-    }
-
     get macros() {
         const macros = this.$store.getters['printer/getMacros']
         const settings = this.$store.state.printer.configfile?.settings.afc ?? {}
 
         const afcMacros = []
+
+        afcMacros.push({
+            icon: mdiWrench,
+            text: this.$t('Panels.AfcPanel.Calibrate'),
+            macroName: 'AFC_CALIBRATION',
+            disabled: this.printerIsPrintingOnly,
+        })
+
+        const ledState = this.afc.led_state ?? false
+        if (ledState) {
+            afcMacros.push({
+                icon: mdiLightbulbOnOutline,
+                text: this.$t('Panels.AfcPanel.LedOff'),
+                macroName: 'TURN_OFF_AFC_LED',
+                disabled: false,
+            })
+        } else {
+            afcMacros.push({
+                icon: mdiLightbulbOutline,
+                text: this.$t('Panels.AfcPanel.LedOn'),
+                macroName: 'TURN_ON_AFC_LED',
+                disabled: false,
+            })
+        }
+
         if (settings.wipe) {
             afcMacros.push({
+                icon: null,
                 text: this.$t('Panels.AfcPanel.BrushNozzle'),
                 macroName: settings?.wipe_cmd || 'AFC_BRUSH',
                 disabled: this.printerIsPrintingOnly,
@@ -103,6 +94,7 @@ export default class AfcPanelButtons extends Mixins(BaseMixin, AfcMixin) {
 
         if (settings.park) {
             afcMacros.push({
+                icon: null,
                 text: this.$t('Panels.AfcPanel.ParkNozzle'),
                 macroName: settings?.park_cmd || 'AFC_PARK',
                 disabled: this.printerIsPrintingOnly,

--- a/src/components/panels/Afc/AfcPanelSettings.vue
+++ b/src/components/panels/Afc/AfcPanelSettings.vue
@@ -27,6 +27,13 @@
                     hide-details
                     :label="$t('Panels.AfcPanel.ShowUnitIcons')" />
             </v-list-item>
+            <v-list-item class="minHeight36">
+                <v-checkbox
+                    v-model="showToolChangeCount"
+                    class="mt-0"
+                    hide-details
+                    :label="$t('Panels.AfcPanel.ShowToolChangeCount')" />
+            </v-list-item>
             <v-divider />
             <afc-panel-settings-extruder v-for="extruder in afcExtruders" :key="extruder" :name="extruder" />
             <afc-panel-settings-unit v-for="unit in afcUnits" :key="unit" :name="unit" />
@@ -57,6 +64,14 @@ export default class AfcPanelSettings extends Mixins(BaseMixin, AfcMixin) {
 
     set showLaneInfinite(value: boolean) {
         this.$store.dispatch('gui/saveSetting', { name: 'view.afc.showLaneInfinite', value })
+    }
+
+    get showToolChangeCount(): boolean {
+        return this.$store.state.gui.view.afc?.showToolChangeCount ?? true
+    }
+
+    set showToolChangeCount(value: boolean) {
+        this.$store.dispatch('gui/saveSetting', { name: 'view.afc.showToolChangeCount', value })
     }
 
     get showUnitIcons(): boolean {

--- a/src/components/panels/Status/PrintstatusPrinting.vue
+++ b/src/components/panels/Status/PrintstatusPrinting.vue
@@ -41,10 +41,10 @@
                     <v-tooltip top>
                         <template #activator="{ on, attrs }">
                             <div v-bind="attrs" v-on="on">
-                                <strong>{{ $t('Panels.StatusPanel.Filament') }}</strong>
+                                <strong>{{ filamentToolchangeText }}</strong>
                                 <br />
                                 <span class="d-block text-center text-no-wrap">
-                                    {{ outputFilamentUsed }}
+                                    {{ filamentToolChangeBody }}
                                 </span>
                             </div>
                         </template>
@@ -135,6 +135,7 @@
 import Component from 'vue-class-component'
 import { Mixins } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
+import AfcMixin from '@/components/mixins/afc'
 import StatusPanelFilesJobqueue from '@/components/panels/Status/Jobqueue.vue'
 import StatusPanelFilesGcodes from '@/components/panels/Status/Gcodefiles.vue'
 
@@ -144,7 +145,7 @@ import StatusPanelFilesGcodes from '@/components/panels/Status/Gcodefiles.vue'
         StatusPanelFilesGcodes,
     },
 })
-export default class StatusPanelPrintstatusPrinting extends Mixins(BaseMixin) {
+export default class StatusPanelPrintstatusPrinting extends Mixins(BaseMixin, AfcMixin) {
     private maxFlow: number = 0
 
     get current_file() {
@@ -232,10 +233,33 @@ export default class StatusPanelPrintstatusPrinting extends Mixins(BaseMixin) {
         return this.$store.state.printer.print_stats?.filament_used ?? 0
     }
 
-    get outputFilamentUsed() {
+    get filamentToolchangeText() {
+        if (this.afc && this.afcShowToolChangeCount && this.current_file.filament_change_count > 0) {
+            return this.$t('Panels.StatusPanel.Toolchange')
+        } else {
+            return this.$t('Panels.StatusPanel.Filament')
+        }
+    }
+
+    get filamentToolChangeBody() {
+        if (this.afc && this.afcShowToolChangeCount && this.current_file.filament_change_count > 0) {
+            return this.toolChangeCount()
+        } else {
+            return this.outputFilamentUsed()
+        }
+    }
+
+    outputFilamentUsed() {
         return this.filament_used >= 1000
             ? (this.filament_used / 1000).toFixed(2) + ' m'
             : this.filament_used.toFixed(2) + ' mm'
+    }
+
+    toolChangeCount() {
+        if (this.afc && this.current_file.filament_change_count > 0) {
+            return `${this.currentFilamentChange} / ${this.current_file.filament_change_count}`
+        }
+        return 0
     }
 
     formatDuration(seconds: number) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -685,6 +685,7 @@
             "ShowFilamentName": "Show Filament Name",
             "ShowLaneInfinite": "Show Infinite Button",
             "ShowTool": "Show Tool \"{name}\"",
+            "ShowToolChangeCount": "Show Toolchange Count",
             "ShowUnit": "Show Unit \"{name}\"",
             "ShowUnitIcons": "Show Unit Icons",
             "ShowUnusedTools": "Show Unused Tools",
@@ -890,6 +891,7 @@
             "ResumePrint": "Resume print",
             "Slicer": "Slicer",
             "Speed": "Speed",
+            "Toolchange": "Toolchange",
             "Total": "Total",
             "TotalTime": "Total Time",
             "Unknown": "Unknown"

--- a/src/store/gui/index.ts
+++ b/src/store/gui/index.ts
@@ -196,6 +196,7 @@ export const getDefaultState = (): GuiState => {
                 showFilamentName: false,
                 showLaneInfinite: true,
                 showUnitIcons: true,
+                showToolChangeCount: true,
             },
             blockFileUpload: false,
             configfiles: {

--- a/src/store/gui/types.ts
+++ b/src/store/gui/types.ts
@@ -138,6 +138,7 @@ export interface GuiState {
             showFilamentName: boolean
             showLaneInfinite: boolean
             showUnitIcons: boolean
+            showToolChangeCount: boolean
         }
         blockFileUpload: boolean
         configfiles: {


### PR DESCRIPTION
## Summary
- merge upstream PR #2271 to add an AFC panel toggle for showing toolchange counts in the status panel
- merge upstream PR #2272 to route AFC panel actions through macro buttons with icons and disabled states

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690165ae285c8326907f05be73341dc0