### PR TITLE
feat: merge upstream afc panel enhancements

### DIFF
--- a/src/components/mixins/afc.ts
+++ b/src/components/mixins/afc.ts
@@ -132,6 +132,10 @@ export default class AfcMixin extends Vue {
         return this.$store.state.gui.view.afc?.showToolChangeCount ?? true
     }
 
+    get afcShowTd1Color(): boolean {
+        return this.$store.state.gui.view.afc?.showTd1Color ?? true
+    }
+
     getPrinterObject(key: string) {
         const printer = this.$store.state.printer ?? {}
         return printer[key] ?? null

--- a/src/components/panels/Afc/AfcFilamentReel.vue
+++ b/src/components/panels/Afc/AfcFilamentReel.vue
@@ -1,5 +1,13 @@
 <template>
-    <svg xmlns="http://www.w3.org/2000/svg" x="0" y="0" viewBox="0 0 256 500" xml:space="preserve" @click="clickSpool">
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        x="0"
+        y="0"
+        viewBox="0 0 256 500"
+        xml:space="preserve"
+        width="100"
+        height="80"
+        @click="clickSpool">
         <path
             id="spool_right_rim"
             d="M202.1,0.3h-5v2.3C179,19,165,123.6,165,250s14,231.1,32.2,247.5v2.3h5

--- a/src/components/panels/Afc/AfcPanelButtons.vue
+++ b/src/components/panels/Afc/AfcPanelButtons.vue
@@ -83,6 +83,15 @@ export default class AfcPanelButtons extends Mixins(BaseMixin, AfcMixin) {
             })
         }
 
+        if (this.afc?.td1_present) {
+            afcMacros.push({
+                icon: '',
+                text: 'Capture TD',
+                macroName: 'AFC_GET_TD_ONE_DATA',
+                disabled: this.printerIsPrintingOnly,
+            })
+        }
+
         if (settings.wipe) {
             afcMacros.push({
                 icon: null,
@@ -112,11 +121,6 @@ export default class AfcPanelButtons extends Mixins(BaseMixin, AfcMixin) {
                 }
             })
             .filter((button) => button.macro !== null)
-    }
-
-    doSend(gcode: string) {
-        this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
-        this.$socket.emit('printer.gcode.script', { script: gcode })
     }
 
     downloadDebugJson() {

--- a/src/components/panels/Afc/AfcPanelSettings.vue
+++ b/src/components/panels/Afc/AfcPanelSettings.vue
@@ -29,6 +29,13 @@
             </v-list-item>
             <v-list-item class="minHeight36">
                 <v-checkbox
+                    v-model="showTd1Color"
+                    class="mt-0"
+                    hide-details
+                    :label="$t('Panels.AfcPanel.ShowTd1Color')" />
+            </v-list-item>
+            <v-list-item class="minHeight36">
+                <v-checkbox
                     v-model="showToolChangeCount"
                     class="mt-0"
                     hide-details
@@ -80,6 +87,14 @@ export default class AfcPanelSettings extends Mixins(BaseMixin, AfcMixin) {
 
     set showUnitIcons(value: boolean) {
         this.$store.dispatch('gui/saveSetting', { name: 'view.afc.showUnitIcons', value })
+    }
+
+    get showTd1Color(): boolean {
+        return this.$store.state.gui.view.afc?.showTd1Color ?? true
+    }
+
+    set showTd1Color(value: boolean) {
+        this.$store.dispatch('gui/saveSetting', { name: 'view.afc.showTd1Color', value })
     }
 }
 </script>

--- a/src/components/panels/Afc/AfcPanelUnitLaneBody.vue
+++ b/src/components/panels/Afc/AfcPanelUnitLaneBody.vue
@@ -38,6 +38,18 @@
                     @close="showInfintiyDialog = false" />
                 <span class="font-weight-bold">{{ spoolMaterial }}</span>
                 <span class="text--disabled">{{ spoolRemainingWeightOutput }}</span>
+                <v-tooltip v-if="tdPresent" top>
+                    <template #activator="{ on, attr }">
+                        <span
+                            v-if="tdPresent"
+                            class="d-flex align-center justify-center text--disable"
+                            v-bind="attr"
+                            v-on="on">
+                            TD - {{ td }}
+                        </span>
+                    </template>
+                    <span>Color - #{{ tdColor }}</span>
+                </v-tooltip>
             </v-col>
         </v-row>
         <v-row v-if="afcShowFilamentName" class="mb-0 mt-n3">
@@ -125,6 +137,10 @@ export default class AfcPanelUnitLaneBody extends Mixins(BaseMixin, AfcMixin) {
     }
 
     get spoolColor() {
+        if (this.afc?.td1_present && this.afcShowTd1Color && this.lane?.td1_color) {
+            return `#${this.lane.td1_color}`
+        }
+
         return this.lane.color || '#000000'
     }
 
@@ -156,6 +172,22 @@ export default class AfcPanelUnitLaneBody extends Mixins(BaseMixin, AfcMixin) {
 
     get spoolFilamentName() {
         return this.spool?.filament?.name ?? 'Unknown'
+    }
+
+    get tdPresent() {
+        if (!this.lane?.td1_td || this.lane.td1_td.length === 0) {
+            return false
+        }
+
+        return true
+    }
+
+    get td() {
+        return this.lane?.td1_td || ''
+    }
+
+    get tdColor() {
+        return this.lane?.td1_color || ''
     }
 
     onFilamentClick() {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -684,6 +684,7 @@
             },
             "ShowFilamentName": "Show Filament Name",
             "ShowLaneInfinite": "Show Infinite Button",
+            "ShowTd1Color": "Show TD-1 Color",
             "ShowTool": "Show Tool \"{name}\"",
             "ShowToolChangeCount": "Show Toolchange Count",
             "ShowUnit": "Show Unit \"{name}\"",

--- a/src/store/gui/index.ts
+++ b/src/store/gui/index.ts
@@ -196,6 +196,7 @@ export const getDefaultState = (): GuiState => {
                 showFilamentName: false,
                 showLaneInfinite: true,
                 showUnitIcons: true,
+                showTd1Color: true,
                 showToolChangeCount: true,
             },
             blockFileUpload: false,

--- a/src/store/gui/types.ts
+++ b/src/store/gui/types.ts
@@ -138,6 +138,7 @@ export interface GuiState {
             showFilamentName: boolean
             showLaneInfinite: boolean
             showUnitIcons: boolean
+            showTd1Color: boolean
             showToolChangeCount: boolean
         }
         blockFileUpload: boolean


### PR DESCRIPTION
## Summary
- resize the AFC filament reel SVG so the upstream dimensions are preserved
- update AFC panel buttons to rely on macro definitions, add the Capture TD macro, and allow optional icons/disable states
- surface TD-1 colour capture details with a user-toggle, tooltip, and persisted GUI setting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690167c80d18832686674b09ef92143a