### PR TITLE
fix: add AMS icon to AFC unit headers

### DIFF
--- a/src/components/panels/Afc/AfcPanelUnit.vue
+++ b/src/components/panels/Afc/AfcPanelUnit.vue
@@ -21,7 +21,7 @@
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import AfcMixin from '@/components/mixins/afc'
-import { afcIconBoxTurtle, afcIconHtlf, afcIconNightOwl, afcIconQuattroBox } from '@/plugins/afcIcons'
+import { afcIconAMS, afcIconBoxTurtle, afcIconHtlf, afcIconNightOwl, afcIconQuattroBox } from '@/plugins/afcIcons'
 import { convertName } from '@/plugins/helpers'
 
 @Component
@@ -65,6 +65,8 @@ export default class AfcPanelUnit extends Mixins(BaseMixin, AfcMixin) {
         switch (this.type) {
             case 'boxturtle':
                 return afcIconBoxTurtle
+            case 'ams':
+                return afcIconAMS
             case 'htlf':
                 return afcIconHtlf
             case 'nightowl':


### PR DESCRIPTION
### Motivation
- AFC units of type `AMS` should display the same per-unit icon as other AFC module types so the panel shows a dedicated AMS icon next to the unit name.

### Description
- Imported `afcIconAMS` from `@/plugins/afcIcons` and added a `case 'ams'` branch to the unit-type-to-icon mapping in `src/components/panels/Afc/AfcPanelUnit.vue` so AMS units return the AMS icon.

### Testing
- Ran `npm run lint` which completed successfully, and attempted `npm run test` which starts the preview server but in this environment the test run stalls after `vite preview` and Cypress execution did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992ce46d1fc8326b52dff567a1407ed)