### PR TITLE
fix: prefer unit.type for AFC unit icon detection (restore AMS icon)

### DIFF
--- a/src/components/panels/Afc/AfcPanelUnit.vue
+++ b/src/components/panels/Afc/AfcPanelUnit.vue
@@ -21,7 +21,7 @@
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import AfcMixin from '@/components/mixins/afc'
-import { afcIconBoxTurtle, afcIconHtlf, afcIconNightOwl, afcIconQuattroBox } from '@/plugins/afcIcons'
+import { afcIconAMS, afcIconBoxTurtle, afcIconHtlf, afcIconNightOwl, afcIconQuattroBox } from '@/plugins/afcIcons'
 import { convertName } from '@/plugins/helpers'
 
 @Component
@@ -54,9 +54,12 @@ export default class AfcPanelUnit extends Mixins(BaseMixin, AfcMixin) {
     }
 
     get type() {
-        const moduleName = this.name.substring(0, this.name.indexOf(' ')).replaceAll('_', '')
+        const typeFromUnit = this.unit?.type
+        if (typeof typeFromUnit === 'string') return typeFromUnit.toLowerCase()
 
-        return moduleName.toLowerCase()
+        const moduleName = this.name.substring(0, this.name.indexOf(' '))
+
+        return moduleName.replace(/^afc_/i, '').replaceAll('_', '').toLowerCase()
     }
 
     get modulIcon() {
@@ -65,6 +68,8 @@ export default class AfcPanelUnit extends Mixins(BaseMixin, AfcMixin) {
         switch (this.type) {
             case 'boxturtle':
                 return afcIconBoxTurtle
+            case 'ams':
+                return afcIconAMS
             case 'htlf':
                 return afcIconHtlf
             case 'nightowl':


### PR DESCRIPTION
### Motivation
- AFC units of type `AMS` were not reliably showing the dedicated AMS icon because icon selection relied only on parsing the unit name.
- Prefer an explicit `unit.type` value from the printer state when available so module-type-to-icon mapping is accurate.

### Description
- Updated `src/components/panels/Afc/AfcPanelUnit.vue` to import `afcIconAMS` and include the `case 'ams'` mapping in the header icon switch.
- Changed the `type` getter to first return `this.unit?.type` (normalized to lower-case) and fall back to stripping an `AFC_` prefix and underscores from the unit name before lower-casing for legacy detection.

### Testing
- Ran `npm run lint` which completed successfully.
- Ran `npm run test` which did not complete in this environment because the run launches `vite preview` and the process timed out before Cypress produced test output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992ce46d1fc8326b52dff567a1407ed)