### PR TITLE
fix: restore OpenAMS FPS display in AFC panel

### DIFF
--- a/src/components/panels/Afc/AfcPanelExtruder.vue
+++ b/src/components/panels/Afc/AfcPanelExtruder.vue
@@ -231,7 +231,7 @@ export default class AfcPanelExtruder extends Mixins(BaseMixin, AfcMixin) {
         const records: Record<string, unknown>[] = []
 
         for (const key of this.extruderFpsConfigKeys) {
-            const candidate = this.getPrinterObject(key)
+            const candidate = this.getFpsStatusRecord(key)
             if (!candidate || typeof candidate !== 'object') continue
 
             records.push(candidate as Record<string, unknown>)
@@ -240,10 +240,23 @@ export default class AfcPanelExtruder extends Mixins(BaseMixin, AfcMixin) {
         return records
     }
 
+    getFpsStatusRecord(configKey: string): Record<string, unknown> | null {
+        const keyCandidates = [configKey]
+        const shortName = configKey.replace(/^fps\s+/i, '').trim()
+        if (shortName && shortName !== configKey) keyCandidates.push(shortName)
+
+        for (const key of keyCandidates) {
+            const candidate = this.getPrinterObject(key)
+            if (candidate && typeof candidate === 'object') return candidate as Record<string, unknown>
+        }
+
+        return null
+    }
+
     readFpsValue(record: Record<string, unknown> | null): number | null {
         if (!record) return null
 
-        const rawValue = record['fps_value']
+        const rawValue = record['fps_value'] ?? record['value']
         if (typeof rawValue === 'number') return Number.isFinite(rawValue) ? rawValue : null
 
         if (typeof rawValue === 'string') {


### PR DESCRIPTION
### Motivation
- Recent OpenAMS/ FPS status naming and payload changes broke the FPS value display in the AFC extruder panel, so the panel needs to accept both legacy and new status keys and value shapes.

### Description
- Added `getFpsStatusRecord(configKey)` to resolve FPS status objects using either the full printer object key (`fps <name>`) or the short name (`<name>`).
- Updated `extruderFpsStatusRecords` to use the new lookup to find status records robustly.
- Extended `readFpsValue` to accept either `fps_value` or the alternate `value` field and safely parse numbers from strings.

### Testing
- Ran formatting with `npm run format` which completed successfully.
- Ran lint auto-fix with `npm run lint:fix` and `npm run lint`, both completed successfully.
- Ran `npm run format:check` which reported a pre-existing formatting warning in `src/store/variables.ts` (unrelated to this change).
- Started the dev server with `npm run serve` and captured a screenshot of the AFC panel to validate the UI change; `npm run test` (full Cypress flow) was started but did not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d2e7e0654832684ea664037ebb740)