### PR TITLE
fix: read OpenAMS FPS from oams status fallback

### DIFF
--- a/src/components/panels/Afc/AfcPanelExtruder.vue
+++ b/src/components/panels/Afc/AfcPanelExtruder.vue
@@ -231,19 +231,49 @@ export default class AfcPanelExtruder extends Mixins(BaseMixin, AfcMixin) {
         const records: Record<string, unknown>[] = []
 
         for (const key of this.extruderFpsConfigKeys) {
-            const candidate = this.getPrinterObject(key)
-            if (!candidate || typeof candidate !== 'object') continue
+            const candidate = this.getFpsStatusRecord(key)
+            if (candidate) records.push(candidate)
 
-            records.push(candidate as Record<string, unknown>)
+            const oamsRecord = this.getOamsStatusRecord(key)
+            if (oamsRecord) records.push(oamsRecord)
         }
 
         return records
     }
 
+    getFpsStatusRecord(configKey: string): Record<string, unknown> | null {
+        const keyCandidates = [configKey]
+        const shortName = configKey.replace(/^fps\s+/i, '').trim()
+        if (shortName && shortName !== configKey) keyCandidates.push(shortName)
+
+        for (const key of keyCandidates) {
+            const candidate = this.getPrinterObject(key)
+            if (candidate && typeof candidate === 'object') return candidate as Record<string, unknown>
+        }
+
+        return null
+    }
+
+    getOamsStatusRecord(configKey: string): Record<string, unknown> | null {
+        const config = this.printerSettingsObject[configKey]
+        if (!config || typeof config !== 'object') return null
+
+        const oamsName = `${(config as Record<string, unknown>)['oams'] ?? ''}`.trim()
+        if (!oamsName) return null
+
+        const oamsKeyCandidates = [`oams ${oamsName}`, oamsName]
+        for (const key of oamsKeyCandidates) {
+            const candidate = this.getPrinterObject(key)
+            if (candidate && typeof candidate === 'object') return candidate as Record<string, unknown>
+        }
+
+        return null
+    }
+
     readFpsValue(record: Record<string, unknown> | null): number | null {
         if (!record) return null
 
-        const rawValue = record['fps_value']
+        const rawValue = record['fps_value'] ?? record['value']
         if (typeof rawValue === 'number') return Number.isFinite(rawValue) ? rawValue : null
 
         if (typeof rawValue === 'string') {


### PR DESCRIPTION
### Motivation
- OpenAMS/ FPS reporting shape can expose live pressure on the mapped OAMS unit status rather than on the FPS object itself, causing the AFC extruder panel to show `-:-` instead of the FPS value. 
- The panel must accept both legacy FPS object keys and the newer OpenAMS unit status keys to reliably display FPS for AMS-managed extruders.

### Description
- Updated `extruderFpsStatusRecords` to aggregate both direct FPS status objects and a fallback OpenAMS unit status resolved from each FPS config's `oams` field. 
- Added `getFpsStatusRecord(configKey)` to try the full `fps <name>` key and the short name variant when locating FPS status objects. 
- Added `getOamsStatusRecord(configKey)` to resolve the referenced OAMS unit (trying `oams <name>` and the bare name) and return its status object as a fallback. 
- Extended `readFpsValue` to accept either `fps_value` or `value` and to safely parse numeric strings into numbers.

### Testing
- Ran `npm run lint` which completed successfully. 
- Ran `npm run test` which launched the preview server and started Cypress but did not complete in this environment and was terminated. 
- Local code changes were compiled and committed for review (modified file: `src/components/panels/Afc/AfcPanelExtruder.vue`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d2e7e0654832684ea664037ebb740)