### PR TITLE
fix: support AFC FPS_buffer status keys for AMS extruders

### DIFF
--- a/src/components/panels/Afc/AfcPanelExtruder.vue
+++ b/src/components/panels/Afc/AfcPanelExtruder.vue
@@ -216,7 +216,7 @@ export default class AfcPanelExtruder extends Mixins(BaseMixin, AfcMixin) {
         if (!normalized) return keys
 
         for (const [key, value] of Object.entries(this.printerSettingsObject)) {
-            if (!/^fps\s+/i.test(key)) continue
+            if (!this.isFpsConfigKey(key)) continue
             if (!value || typeof value !== 'object') continue
 
             const record = value as Record<string, unknown>
@@ -241,9 +241,18 @@ export default class AfcPanelExtruder extends Mixins(BaseMixin, AfcMixin) {
         return records
     }
 
+
+    isFpsConfigKey(key: string): boolean {
+        return /^fps(?:\s+.+|_buffer\d+)$/i.test(key)
+    }
+
+    normalizeFpsStatusKey(configKey: string): string {
+        return configKey.replace(/^fps(?:\s+|_)/i, '').trim()
+    }
+
     getFpsStatusRecord(configKey: string): Record<string, unknown> | null {
         const keyCandidates = [configKey]
-        const shortName = configKey.replace(/^fps\s+/i, '').trim()
+        const shortName = this.normalizeFpsStatusKey(configKey)
         if (shortName && shortName !== configKey) keyCandidates.push(shortName)
 
         for (const key of keyCandidates) {


### PR DESCRIPTION
### Motivation
- The AMS extruder buffer status keys are now sometimes named like `FPS_buffer1`/`FPS_buffer2` instead of the legacy `fps ...` sections, and the buffer column should continue to show the live FPS value for devices using those keys. 
- Update the FPS config-key detection and status lookup so underscore-delimited `FPS_buffer#` keys are recognized and normalized the same as space-prefixed `fps ...` keys.

### Description
- Added `isFpsConfigKey(key: string)` which detects both legacy `fps <name>` keys and new `fps_buffer#`/`FPS_buffer#` style keys using a regex. (file: `src/components/panels/Afc/AfcPanelExtruder.vue`) 
- Added `normalizeFpsStatusKey(configKey: string)` to strip either the `fps ` or `fps_` prefix so status lookup uses the same short name for both key styles. (file: `src/components/panels/Afc/AfcPanelExtruder.vue`) 
- Updated `extruderFpsConfigKeys` to use `isFpsConfigKey` and updated `getFpsStatusRecord` to use `normalizeFpsStatusKey` so AMS extruders continue to resolve and display live FPS values in the buffer column. (file: `src/components/panels/Afc/AfcPanelExtruder.vue`)

### Testing
- Ran `npm run lint` and the linter completed successfully. 
- Ran `npm run test` which invokes `start-server-and-test`, but the test run failed in this environment due to a timeout waiting for `http://127.0.0.1:4173/` to become available during the preview server startup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba2c5648708326a4cd006dd5182df3)