### PR TITLE
Normalize FPS config keys and extend FPS status lookup in AfcPanelExtruder

### DIFF
--- a/src/components/panels/Afc/AfcPanelExtruder.vue
+++ b/src/components/panels/Afc/AfcPanelExtruder.vue
@@ -216,7 +216,7 @@ export default class AfcPanelExtruder extends Mixins(BaseMixin, AfcMixin) {
         if (!normalized) return keys
 
         for (const [key, value] of Object.entries(this.printerSettingsObject)) {
-            if (!/^fps\s+/i.test(key)) continue
+            if (!this.isFpsConfigKey(key)) continue
             if (!value || typeof value !== 'object') continue
 
             const record = value as Record<string, unknown>
@@ -241,10 +241,22 @@ export default class AfcPanelExtruder extends Mixins(BaseMixin, AfcMixin) {
         return records
     }
 
+
+    isFpsConfigKey(key: string): boolean {
+        return /^fps(?:\s+.+|_buffer\d+)$/i.test(key)
+    }
+
+    normalizeFpsStatusKey(configKey: string): string {
+        return configKey.replace(/^fps(?:\s+|_)/i, '').trim()
+    }
+
     getFpsStatusRecord(configKey: string): Record<string, unknown> | null {
-        const keyCandidates = [configKey]
-        const shortName = configKey.replace(/^fps\s+/i, '').trim()
-        if (shortName && shortName !== configKey) keyCandidates.push(shortName)
+        const keyCandidates = [configKey, `AFC_FPS ${configKey}`]
+        const shortName = this.normalizeFpsStatusKey(configKey)
+
+        if (shortName && shortName !== configKey) {
+            keyCandidates.push(shortName, `AFC_FPS ${shortName}`)
+        }
 
         for (const key of keyCandidates) {
             const candidate = this.getPrinterObject(key)


### PR DESCRIPTION
### Motivation
- Ensure FPS configuration keys are recognized in multiple formats (space-separated, underscore, and buffer suffixes) so extruder FPS records are discovered reliably.
- Simplify and centralize key-matching logic to make status record lookups more robust against variations in key naming.

### Description
- Added `isFpsConfigKey` to detect `fps` config keys using the pattern `/^fps(?:\s+.+|_buffer\d+)$/i`.
- Added `normalizeFpsStatusKey` to strip `fps ` or `fps_` prefixes and trim the resulting short name.
- Updated `extruderFpsConfigKeys` to use `isFpsConfigKey` for filtering printer settings keys.
- Extended `getFpsStatusRecord` to probe additional key candidates including `AFC_FPS <key>` variants and normalized short names.

### Testing
- Ran linting with `npm run lint` and the linter completed successfully.
- Executed unit tests with `npm run test:unit` and all tests passed.
- Performed a project build with `npm run build` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba2c5648708326a4cd006dd5182df3)